### PR TITLE
Upgrade to the latest version of sqlite for win8 and wp8

### DIFF
--- a/CompletedSource/UnicornClicker/UnicornClicker/UnicornClicker.Windows/UnicornClicker.Windows.csproj
+++ b/CompletedSource/UnicornClicker/UnicornClicker/UnicornClicker.Windows/UnicornClicker.Windows.csproj
@@ -133,7 +133,7 @@
     <SDKReference Include="Microsoft.VCLibs, version=12.0">
       <Name>Microsoft Visual C++ 2013 Runtime Package for Windows</Name>
     </SDKReference>
-    <SDKReference Include="SQLite.WinRT81, Version=3.8.5">
+    <SDKReference Include="SQLite.WinRT81, Version=3.8.8.3">
       <Name>SQLite for Windows Runtime %28Windows 8.1%29</Name>
     </SDKReference>
   </ItemGroup>

--- a/CompletedSource/UnicornClicker/UnicornClicker/UnicornClicker.Windows/UnicornClicker.Windows.csproj
+++ b/CompletedSource/UnicornClicker/UnicornClicker/UnicornClicker.Windows/UnicornClicker.Windows.csproj
@@ -133,7 +133,7 @@
     <SDKReference Include="Microsoft.VCLibs, version=12.0">
       <Name>Microsoft Visual C++ 2013 Runtime Package for Windows</Name>
     </SDKReference>
-    <SDKReference Include="SQLite.WinRT81, Version=3.8.8.3">
+    <SDKReference Include="SQLite.WinRT81, Version=3.8.10">
       <Name>SQLite for Windows Runtime %28Windows 8.1%29</Name>
     </SDKReference>
   </ItemGroup>

--- a/CompletedSource/UnicornClicker/UnicornClicker/UnicornClicker.WindowsPhone/UnicornClicker.WindowsPhone.csproj
+++ b/CompletedSource/UnicornClicker/UnicornClicker/UnicornClicker.WindowsPhone/UnicornClicker.WindowsPhone.csproj
@@ -124,7 +124,7 @@
     <SDKReference Include="Microsoft.VCLibs, version=12.0">
       <Name>Microsoft Visual C++ 2013 Runtime Package for Windows Phone</Name>
     </SDKReference>
-    <SDKReference Include="SQLite.WP81, Version=3.8.8.3">
+    <SDKReference Include="SQLite.WP81, Version=3.8.10">
       <Name>SQLite for Windows Phone 8.1</Name>
     </SDKReference>
   </ItemGroup>

--- a/CompletedSource/UnicornClicker/UnicornClicker/UnicornClicker.WindowsPhone/UnicornClicker.WindowsPhone.csproj
+++ b/CompletedSource/UnicornClicker/UnicornClicker/UnicornClicker.WindowsPhone/UnicornClicker.WindowsPhone.csproj
@@ -124,7 +124,7 @@
     <SDKReference Include="Microsoft.VCLibs, version=12.0">
       <Name>Microsoft Visual C++ 2013 Runtime Package for Windows Phone</Name>
     </SDKReference>
-    <SDKReference Include="SQLite.WP81, Version=3.8.5">
+    <SDKReference Include="SQLite.WP81, Version=3.8.8.3">
       <Name>SQLite for Windows Phone 8.1</Name>
     </SDKReference>
   </ItemGroup>

--- a/StartingSource/UnicornClicker/UnicornClicker/UnicornClicker.Windows/UnicornClicker.Windows.csproj
+++ b/StartingSource/UnicornClicker/UnicornClicker/UnicornClicker.Windows/UnicornClicker.Windows.csproj
@@ -133,7 +133,7 @@
     <SDKReference Include="Microsoft.VCLibs, version=12.0">
       <Name>Microsoft Visual C++ 2013 Runtime Package for Windows</Name>
     </SDKReference>
-    <SDKReference Include="SQLite.WinRT81, Version=3.8.8.1">
+    <SDKReference Include="SQLite.WinRT81, Version=3.8.8.3">
       <Name>SQLite for Windows Runtime %28Windows 8.1%29</Name>
     </SDKReference>
   </ItemGroup>

--- a/StartingSource/UnicornClicker/UnicornClicker/UnicornClicker.Windows/UnicornClicker.Windows.csproj
+++ b/StartingSource/UnicornClicker/UnicornClicker/UnicornClicker.Windows/UnicornClicker.Windows.csproj
@@ -133,7 +133,7 @@
     <SDKReference Include="Microsoft.VCLibs, version=12.0">
       <Name>Microsoft Visual C++ 2013 Runtime Package for Windows</Name>
     </SDKReference>
-    <SDKReference Include="SQLite.WinRT81, Version=3.8.8.3">
+    <SDKReference Include="SQLite.WinRT81, Version=3.8.10">
       <Name>SQLite for Windows Runtime %28Windows 8.1%29</Name>
     </SDKReference>
   </ItemGroup>

--- a/StartingSource/UnicornClicker/UnicornClicker/UnicornClicker.Windows/UnicornClicker.Windows.csproj
+++ b/StartingSource/UnicornClicker/UnicornClicker/UnicornClicker.Windows/UnicornClicker.Windows.csproj
@@ -133,7 +133,7 @@
     <SDKReference Include="Microsoft.VCLibs, version=12.0">
       <Name>Microsoft Visual C++ 2013 Runtime Package for Windows</Name>
     </SDKReference>
-    <SDKReference Include="SQLite.WinRT81, Version=3.8.5">
+    <SDKReference Include="SQLite.WinRT81, Version=3.8.8.1">
       <Name>SQLite for Windows Runtime %28Windows 8.1%29</Name>
     </SDKReference>
   </ItemGroup>

--- a/StartingSource/UnicornClicker/UnicornClicker/UnicornClicker.WindowsPhone/UnicornClicker.WindowsPhone.csproj
+++ b/StartingSource/UnicornClicker/UnicornClicker/UnicornClicker.WindowsPhone/UnicornClicker.WindowsPhone.csproj
@@ -124,7 +124,7 @@
     <SDKReference Include="Microsoft.VCLibs, version=12.0">
       <Name>Microsoft Visual C++ 2013 Runtime Package for Windows Phone</Name>
     </SDKReference>
-    <SDKReference Include="SQLite.WP81, Version=3.8.8.3">
+    <SDKReference Include="SQLite.WP81, Version=3.8.10">
       <Name>SQLite for Windows Phone 8.1</Name>
     </SDKReference>
   </ItemGroup>

--- a/StartingSource/UnicornClicker/UnicornClicker/UnicornClicker.WindowsPhone/UnicornClicker.WindowsPhone.csproj
+++ b/StartingSource/UnicornClicker/UnicornClicker/UnicornClicker.WindowsPhone/UnicornClicker.WindowsPhone.csproj
@@ -124,7 +124,7 @@
     <SDKReference Include="Microsoft.VCLibs, version=12.0">
       <Name>Microsoft Visual C++ 2013 Runtime Package for Windows Phone</Name>
     </SDKReference>
-    <SDKReference Include="SQLite.WP81, Version=3.8.8.1">
+    <SDKReference Include="SQLite.WP81, Version=3.8.8.3">
       <Name>SQLite for Windows Phone 8.1</Name>
     </SDKReference>
   </ItemGroup>

--- a/StartingSource/UnicornClicker/UnicornClicker/UnicornClicker.WindowsPhone/UnicornClicker.WindowsPhone.csproj
+++ b/StartingSource/UnicornClicker/UnicornClicker/UnicornClicker.WindowsPhone/UnicornClicker.WindowsPhone.csproj
@@ -124,7 +124,7 @@
     <SDKReference Include="Microsoft.VCLibs, version=12.0">
       <Name>Microsoft Visual C++ 2013 Runtime Package for Windows Phone</Name>
     </SDKReference>
-    <SDKReference Include="SQLite.WP81, Version=3.8.5">
+    <SDKReference Include="SQLite.WP81, Version=3.8.8.1">
       <Name>SQLite for Windows Phone 8.1</Name>
     </SDKReference>
   </ItemGroup>


### PR DESCRIPTION
I've upgraded the sqlite dependencies to the latest package that you suggest to download from vs gallery, otherwise it wouldn't compile with the old reference 3.8.5:
- [SQLite for Windows Phone 8.1](http://visualstudiogallery.msdn.microsoft.com/5d97faf6-39e3-4048-a0bc-adde2af75d1b)
- [SQLite for Windows Runtime (Windows 8.1) ](http://visualstudiogallery.msdn.microsoft.com/1d04f82f-2fe9-4727-a2f9-a2db127ddc9a)

If we want to avoid this kind of upgrade in the future, we should add the .vsxi package directly in this git repo, what do you think? If you like to add the vsxi packages, I can update this PR, the extra space required will be 6.64 MB for both packages, but probably for a demo repo it worth.
